### PR TITLE
Added height & width customization to prevent RenderFlex overflow issues

### DIFF
--- a/lib/custom.dialog.dart
+++ b/lib/custom.dialog.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 
 class CustomDialog extends StatelessWidget {
-  const CustomDialog({Key? key, required this.child}) : super(key: key);
+  const CustomDialog({Key? key, required this.child, this.height, this.width}) : super(key: key);
 
   final Widget child;
+  final double? height;
+  final double? width;
 
   @override
   Widget build(BuildContext context) {

--- a/lib/simple_month_year_picker.dart
+++ b/lib/simple_month_year_picker.dart
@@ -52,6 +52,8 @@ class SimpleMonthYearPicker {
     Color? selectionColor,
     bool? barrierDismissible,
     bool? disableFuture,
+    double? height,
+    double? width,
   }) async {
     final ThemeData theme = Theme.of(context);
     var primaryColor = selectionColor ?? theme.primaryColor;
@@ -73,8 +75,8 @@ class SimpleMonthYearPicker {
             child: Stack(
               children: [
                 Container(
-                  height: 210,
-                  width: 370,
+                  height: height ?? 210,
+                  width: width ?? 370,
                   decoration: BoxDecoration(
                     color: bgColor,
                     border: Border.all(


### PR DESCRIPTION
- Added an optional `height` and  `width` parameters to allow custom dialog sizing.
- Prevents RenderFlex overflow issues on small screens.
- Defaults to 210px height and 370px width if no custom height and width are provided.